### PR TITLE
TFG - Canviar plantilla HTML

### DIFF
--- a/internal/render/html/home.html.tmpl
+++ b/internal/render/html/home.html.tmpl
@@ -60,7 +60,7 @@
             <td>{{index .StringMap "ipAddress"}}</td>
         </tr>
         <tr>
-            <td style="font-weight: bold;">Versió del codi</td>
+            <td style="font-weight: bold;">Versió (commit hash)</td>
             <td>{{index .StringMap "gitCommit"}}</td>
         </tr>
         </tbody>


### PR DESCRIPTION
Canviar plantilla HTML per mostrar `Versió (commit hash)` en comptes de `Versió codi`.